### PR TITLE
Remove Summer 2018 from invest

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -117,7 +117,7 @@
           <div class="row">
             <div class="col-sm-6">
               <h4 data-l10n-id="ready-to-invest">Ready to invest?</h4>
-              <h2 data-l10n-id="sell-plan">Chia will be available to the public in the summer of 2018</h2>
+              <h2 data-l10n-id="sell-plan">Chia will be widely available to the public soon</h2>
             </div>
             <div class="col-sm-6">
               <div class="centered">


### PR DESCRIPTION
September isn't exactly summer so best to move to "soon" or somesuch language as it has the added benefit of being true. Added "widely" because we get so many questions about non accredited investors.